### PR TITLE
Fix override key bug

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -528,7 +528,7 @@ mod tests {
     }
 
     /// This test is ported from [softprops/envy](https://github.com/softprops/envy/blob/801d81e7c3e443470e110bf4e34460acba113476/src/lib.rs#L410)
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(Deserialize, Debug, PartialEq, Eq)]
     pub struct Foo {
         bar: String,
         baz: bool,
@@ -554,7 +554,7 @@ mod tests {
         8080
     }
 
-    #[derive(Deserialize, Debug, PartialEq, Default)]
+    #[derive(Deserialize, Debug, PartialEq, Eq, Default)]
     pub struct CustomNewType(u32);
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -94,7 +94,10 @@ impl Node {
 
         match k.split_once('_') {
             None => {
-                self.1.insert(k.to_string(), Self::new(v));
+                self.1
+                    .entry(k.to_string())
+                    .or_insert_with(|| Node::new(""))
+                    .0 = v.to_string();
             }
             Some((k, remain)) => match self.1.get_mut(k) {
                 None => {
@@ -158,6 +161,7 @@ mod tests {
         root.push("a_b_c_d", "Hello, World!");
         root.push("a_b_c_e", "Hello, Mars!");
         root.push("a_b_f", "Hello, Moon!");
+        root.push("a", "Hello, Earth!");
 
         assert_eq!(
             root,
@@ -166,7 +170,7 @@ mod tests {
                 BTreeMap::from([(
                     "a".to_string(),
                     Node(
-                        "".to_string(),
+                        "Hello, Earth!".to_string(),
                         BTreeMap::from([(
                             "b".to_string(),
                             Node(


### PR DESCRIPTION
Fixed a bug where inserting in the order `a_b=x`, `a=y` overwrote keys.
I also added a test.

This is the log of the added test before the fix.
```
$ cargo test 
   Compiling serde-env v0.0.2 (/Volumes/Develop/github/kgtkr/serde-env)
    Finished test [unoptimized + debuginfo] target(s) in 0.69s
     Running unittests src/lib.rs (target/debug/deps/serde_env-26d62904ea096b0f)

running 11 tests
test de::tests::test_from_env_alias ... ignored
test value::tests::test_get ... ok
test value::tests::test_flatten ... ok
test value::tests::test_push ... FAILED
test de::tests::test_ported_from_envy ... ok
test de::tests::test_from_env_flat_upper ... ok
test de::tests::test_from_env_flat_upper_with_default ... ok
test de::tests::test_from_env_as_map ... ok
test de::tests::test_from_env_flat_with_default ... ok
test de::tests::test_from_env_flat ... ok
test de::tests::test_from_env ... ok

failures:

---- value::tests::test_push stdout ----
thread 'value::tests::test_push' panicked at 'assertion failed: `(left == right)`
  left: `{"a": Hello, Earth!}`,
 right: `{"a": ["Hello, Earth!", {"b": {"c": {"d": Hello, World!, "e": Hello, Mars!}, "f": Hello, Moon!}}]}`', src/value.rs:163:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    value::tests::test_push

test result: FAILED. 9 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: test failed, to rerun pass '--lib'
```