### PR TITLE
feat: Disable logging in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.1"
 [dependencies]
 serde = "1"
 anyhow = "1"
-log = "0.4"
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
If this crate is used in a production environment with trace/debug logging level enabled, it prints out all secrets stored in envrionment variables to the logs. As most projects don't need environment variable logging at all, the logging feature is hidden behind a feature flag, completely avoiding runtime checks.