### PR TITLE
feat: Feature-flagged logging

### DIFF
--- a/src/cond_log.rs
+++ b/src/cond_log.rs
@@ -1,0 +1,29 @@
+#[cfg(debug_assertions)]
+pub(crate) use log::debug;
+
+#[cfg(debug_assertions)]
+pub(crate) use log::trace;
+
+#[cfg(not(debug_assertions))]
+macro_rules! debug {
+    ($($arg:tt)+) => {
+        // Debug logging disabled in `release` profile
+    };
+}
+
+#[cfg(not(debug_assertions))]
+pub(crate) use debug;
+
+#[cfg(not(debug_assertions))]
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)+) => {
+        $($arg)+
+        // Trace logging disabled in `release` profile
+    };
+    ($($arg:tt)+) => {
+        // Trace logging disabled in `release` profile
+    };
+}
+
+#[cfg(not(debug_assertions))]
+pub(crate) use trace;

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use crate::cond_log::debug;
 use serde::de::{DeserializeSeed, IntoDeserializer, SeqAccess, Visitor};
 use serde::{de, forward_to_deserialize_any};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //! println!("{:?}", t)
 //! ```
 
+mod cond_log;
 mod de;
 mod error;
 mod value;

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 use std::{env, fmt};
 
-use log::trace;
+use crate::cond_log::trace;
 
 /// Node represents a tree of env values.
 ///


### PR DESCRIPTION
Disabling logging in production via `release_max_level_off` disables logging for the whole resulting lib/binary, not just the `serde-env` crate. A workaround would be an opt-in feature, disabled by default.