### PR TITLE
fix: Use logging-only variables in `release` profile

### DIFF
--- a/src/cond_log.rs
+++ b/src/cond_log.rs
@@ -8,6 +8,8 @@ pub(crate) use log::trace;
 macro_rules! debug {
     ($($arg:tt)+) => {
         // Debug logging disabled in `release` profile
+        // Effectively a noop - result ignored by rustc in `release` profile
+        format_args!($($arg)+)
     };
 }
 
@@ -16,12 +18,10 @@ pub(crate) use debug;
 
 #[cfg(not(debug_assertions))]
 macro_rules! trace {
-    (target: $target:expr, $($arg:tt)+) => {
-        $($arg)+
-        // Trace logging disabled in `release` profile
-    };
     ($($arg:tt)+) => {
         // Trace logging disabled in `release` profile
+        // Effectively a noop - result ignored by rustc in `release` profile
+        format_args!($($arg)+)
     };
 }
 


### PR DESCRIPTION
Due to the logging format used, the existing `format_args` macro matches the logging macro args. It can be used to consume the variables used for logging, yet the output isn't used anywhere. Because this only happens in the `release` profile, `rustc` will remove the code completely.