### PR TITLE
perf: Avoid sorting and deduplicating in Node.flatten

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::cond_log::debug;
 use serde::de::{DeserializeSeed, IntoDeserializer, SeqAccess, Visitor};
 use serde::{de, forward_to_deserialize_any};
@@ -335,12 +337,12 @@ impl<'de> SeqAccess<'de> for SeqAccessor {
 
 struct MapAccessor {
     last_value: Option<Node>,
-    keys: std::vec::IntoIter<String>,
+    keys: std::collections::hash_set::IntoIter<String>,
     node: Node,
 }
 
 impl MapAccessor {
-    fn new(keys: Vec<String>, node: Node) -> Self {
+    fn new(keys: HashSet<String>, node: Node) -> Self {
         debug!("access keys {:?} from map", keys);
 
         Self {
@@ -413,13 +415,12 @@ impl<'de> de::EnumAccess<'de> for EnumAccessor {
     type Error = Error;
     type Variant = VariantAccessor;
 
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
     where
         V: DeserializeSeed<'de>,
     {
         let key = self
             .keys
-            .into_iter()
             .find(|key| self.node.value() == key)
             .ok_or_else(|| de::Error::custom("no variant found"))?;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::{env, fmt};
 
@@ -54,8 +54,8 @@ impl Node {
         !self.1.is_empty()
     }
 
-    pub fn flatten(&self, prefix: &str) -> Vec<String> {
-        let mut m = Vec::new();
+    pub fn flatten(&self, prefix: &str) -> HashSet<String> {
+        let mut m = HashSet::new();
 
         for (key, value) in self.1.iter() {
             let prefix_key = if prefix.is_empty() {
@@ -65,16 +65,13 @@ impl Node {
             };
 
             if !value.0.is_empty() {
-                m.push(prefix_key.clone())
+                m.insert(prefix_key.clone());
             }
             if !value.1.is_empty() {
-                m.push(prefix_key.clone());
+                m.insert(prefix_key.clone());
                 m.extend(value.flatten(&prefix_key))
             }
         }
-
-        m.sort();
-        m.dedup();
 
         m
     }
@@ -213,9 +210,14 @@ mod tests {
         root.push("a_b_c_e", "Hello, Mars!");
         root.push("a_b_f", "Hello, Moon!");
 
-        assert_eq!(
-            root.flatten(""),
-            vec!["a", "a_b", "a_b_c", "a_b_c_d", "a_b_c_e", "a_b_f"]
-        );
+        let mut expected = HashSet::<String>::new();
+        expected.insert("a".to_owned());
+        expected.insert("a_b".to_owned());
+        expected.insert("a_b_c".to_owned());
+        expected.insert("a_b_c_d".to_owned());
+        expected.insert("a_b_c_e".to_owned());
+        expected.insert("a_b_f".to_owned());
+
+        assert_eq!(root.flatten(""), expected);
     }
 }


### PR DESCRIPTION
With `Vec` in place, flattening takes a merge sort, which is `O(n*log(n))`. Then, an additional pass to deduplicate O(n) is required. This can be avoided by using a HashSet, which is guaranteed to be O(1) on insert. Also, a HashSet doesn't need any intermediate memory allocations.