### PR TITLE
fix: Remove log crate's features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.1"
 [dependencies]
 serde = "1"
 anyhow = "1"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
+log = "0.4"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
The `release_max_level_off` and `max_level_trace` in prod were replaced by a noop and are not unly no longer needed, but also force downstream crates to disable logging in optimized releases.