### PR TITLE
feat: Opt-in logging via feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ version = "0.1.1"
 [dependencies]
 serde = "1"
 anyhow = "1"
-log = "0.4"
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 temp-env = "0.3"
 env_logger = "0.10"
+
+[features]
+log = ["dep:log"]

--- a/src/cond_log.rs
+++ b/src/cond_log.rs
@@ -1,10 +1,10 @@
-#[cfg(debug_assertions)]
+#[cfg(feature = "log")]
 pub(crate) use log::debug;
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "log")]
 pub(crate) use log::trace;
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "log"))]
 macro_rules! debug {
     ($($arg:tt)+) => {
         // Debug logging disabled in `release` profile
@@ -13,10 +13,10 @@ macro_rules! debug {
     };
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "log"))]
 pub(crate) use debug;
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "log"))]
 macro_rules! trace {
     ($($arg:tt)+) => {
         // Trace logging disabled in `release` profile
@@ -25,5 +25,5 @@ macro_rules! trace {
     };
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "log"))]
 pub(crate) use trace;


### PR DESCRIPTION
Logging in `debug` mode can still be considered a security problem by some. First, `debug` may be used in non-prod environments, yet those environments still have secrets. Second, it only takes deploying a debug build by mistake to reveal environment's secrets. This is a huge potential risk. Therefore, as a final solution to this, I propose leaving logging off by default. Also, this crate itself will be lighter without the `log` dependency.

Thank you for considering this proposal.