### PR TITLE
Make Error struct accessible outside the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,4 @@ mod error;
 mod value;
 
 pub use de::from_env;
+pub use error::Error;


### PR DESCRIPTION
Because the `Error` is not accessible from outside the crate I cannot implement `From` (either manually or via `thiserror`s `#[from]` and the like).
Without this I'm basically forced to `to_string` the error and wrap that with my own error type.

Not that I need more than just a string to output the description of the error, but it's a little bit annoying that I have to do it manually, while `#[from]` could do everything for me.