### PR TITLE
build: v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Xuanwo/serde-env"
 edition = "2021"
 license = "Apache-2.0"
 name = "serde-env"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
 serde = "1"


### PR DESCRIPTION
@Xuanwo Would it please be possible to `cargo release` a new version, without the logging vulnerability ? :bow: 

This is a breaking change (feature removed) and before major `1.0.0`, the minor version can contain breaking changes, so I bumped that to `0.2.0`.