### PR TITLE
Implement deserialize_any

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_with = { version = "3", features = ["json"] }
 temp-env = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 


### PR DESCRIPTION
Given that serde-env is always parsing a string, `deserialize_any` should be implemented as parsing strings.