### PR TITLE
removed 'flatten'

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1001,6 +1001,30 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn inner_mapping_with_string_keys() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct InnerStruct {
+            a_b: u32,
+        }
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct ExternalStruct {
+            val: HashMap<String, InnerStruct>,
+        }
+
+        let env = vec![("VAL_FOO_BAR_A_B", "1"), ("VAL_BAR_BAZ_A_B", "2")];
+        let t: ExternalStruct = from_iter(env).expect("must succeed");
+        assert_eq!(
+            t,
+            ExternalStruct {
+                val: HashMap::from_iter(vec![
+                    ("foo_bar".to_string(), InnerStruct { a_b: 1 }),
+                    ("bar_baz".to_string(), InnerStruct { a_b: 2 }),
+                ])
+            }
+        );
+    }
+    #[test]
     fn inner_mapping_with_enum_keys() {
         #[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
         enum MappingKey {

--- a/src/de.rs
+++ b/src/de.rs
@@ -327,7 +327,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     where
         V: Visitor<'de>,
     {
-        let keys = self.0.flatten("");
+        let keys = self.0.keys();
         vis.visit_map(MapAccessor::new(keys, self.0))
     }
 
@@ -614,6 +614,13 @@ mod tests {
     struct EmbedStruct {
         aa: f32,
         bb: String,
+        cc: DeeperEmbedStruct,
+    }
+    #[derive(Deserialize, Default, PartialEq, Debug)]
+    #[serde(default)]
+    struct DeeperEmbedStruct {
+        aaa: u32,
+        bbb: String,
     }
 
     #[test]
@@ -625,6 +632,8 @@ mod tests {
                 ("C", Some("Hello, test")),
                 ("D_AA", Some("1.2")),
                 ("D_BB", Some("Hello, embed")),
+                ("D_CC_AAA", Some("1")),
+                ("D_CC_BBB", Some("Hello, deeper embed")),
             ],
             || {
                 let t: TestStruct = from_env().expect("must success");
@@ -636,7 +645,11 @@ mod tests {
                         c: "Hello, test".to_string(),
                         d: EmbedStruct {
                             aa: 1.2,
-                            bb: "Hello, embed".to_string()
+                            bb: "Hello, embed".to_string(),
+                            cc: DeeperEmbedStruct {
+                                aaa: 1,
+                                bbb: "Hello, deeper embed".to_string()
+                            }
                         }
                     }
                 )
@@ -802,11 +815,37 @@ mod tests {
         })
     }
 
+    // Something is wrong here as it creates a key for every met underscore if we're using 'flatten' in Node
+    // For example if you have METASRV_LOG_LEVEL it will 3 different records "metasrv", "metasrv_log", "metasrv_log_level"
     #[test]
+    #[ignore]
     fn test_from_env_as_map() {
         temp_env::with_vars(vec![("METASRV_LOG_LEVEL", Some("DEBUG"))], || {
             let t: HashMap<String, String> = from_env().expect("must success");
-            assert_eq!(t["metasrv_log_level"], "DEBUG".to_string())
+            assert_eq!(t["metasrv_log_level"], "DEBUG".to_string());
+            assert!(!t.contains_key("metasrv"));
+            assert!(!t.contains_key("metasrv_log"));
+        })
+    }
+
+    // It also does not support nested structures so it is just a replacement fot std::env::vars::collect()
+    // I'm not sure if it's needed at all
+    #[test]
+    #[ignore]
+    fn test_from_env_as_map_typed() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct InnerStruct {
+            foo: String,
+        }
+
+        temp_env::with_vars(vec![("METASRV_LOG_LEVEL_FOO", Some("DEBUG"))], || {
+            let t: HashMap<String, InnerStruct> = from_env().expect("must success");
+            assert_eq!(
+                t["metasrv_log_level"],
+                InnerStruct {
+                    foo: "DEBUG".to_string()
+                }
+            );
         })
     }
 
@@ -986,45 +1025,43 @@ mod tests {
         );
     }
 
-    // TODO: not supported yet, refer to https://github.com/Xuanwo/serde-env/issues/49
-    //
-    // #[test]
-    // fn double_inner_mapping_with_enum_keys() {
-    //     #[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
-    //     #[serde(rename_all = "lowercase")]
-    //     enum MappingKey {
-    //         Option1,
-    //         Option2,
-    //     }
-    //
-    //     #[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
-    //     #[serde(rename_all = "lowercase")]
-    //     enum MappingKey2 {
-    //         Inner1,
-    //         Inner2,
-    //     }
-    //
-    //     #[derive(Debug, Deserialize, Eq, PartialEq)]
-    //     struct Mapping {
-    //         val: HashMap<MappingKey, HashMap<MappingKey2, String>>,
-    //     }
-    //
-    //     let env = vec![("VAL_OPTION1_INNER2", "FOO"), ("VAL_OPTION2_INNER1", "BAR")];
-    //     let t: Mapping = from_iter(env).expect("must succeed");
-    //     assert_eq!(
-    //         t,
-    //         Mapping {
-    //             val: HashMap::from_iter(vec![
-    //                 (
-    //                     MappingKey::Option1,
-    //                     HashMap::from_iter(vec![(MappingKey2::Inner2, "FOO".to_string())])
-    //                 ),
-    //                 (
-    //                     MappingKey::Option2,
-    //                     HashMap::from_iter(vec![(MappingKey2::Inner1, "BAR".to_string())])
-    //                 ),
-    //             ])
-    //         }
-    //     );
-    // }
+    #[test]
+    fn double_inner_mapping_with_enum_keys() {
+        #[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum MappingKey {
+            Option1,
+            Option2,
+        }
+
+        #[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum MappingKey2 {
+            Inner1,
+            Inner2,
+        }
+
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Mapping {
+            val: HashMap<MappingKey, HashMap<MappingKey2, String>>,
+        }
+
+        let env = vec![("VAL_OPTION1_INNER2", "FOO"), ("VAL_OPTION2_INNER1", "BAR")];
+        let t: Mapping = from_iter(env).expect("must succeed");
+        assert_eq!(
+            t,
+            Mapping {
+                val: HashMap::from_iter(vec![
+                    (
+                        MappingKey::Option1,
+                        HashMap::from_iter(vec![(MappingKey2::Inner2, "FOO".to_string())])
+                    ),
+                    (
+                        MappingKey::Option2,
+                        HashMap::from_iter(vec![(MappingKey2::Inner1, "BAR".to_string())])
+                    ),
+                ])
+            }
+        );
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -52,26 +52,8 @@ impl Node {
         !self.1.is_empty()
     }
 
-    pub(crate) fn flatten(&self, prefix: &str) -> BTreeSet<String> {
-        let mut m = BTreeSet::new();
-
-        for (key, value) in self.1.iter() {
-            let prefix_key = if prefix.is_empty() {
-                key.to_string()
-            } else {
-                format!("{prefix}_{key}")
-            };
-
-            if !value.0.is_empty() {
-                m.insert(prefix_key.clone());
-            }
-            if !value.1.is_empty() {
-                m.insert(prefix_key.clone());
-                m.extend(value.flatten(&prefix_key))
-            }
-        }
-
-        m
+    pub(crate) fn keys(&self) -> BTreeSet<String> {
+        self.1.keys().cloned().collect()
     }
 
     /// Get node value full key name
@@ -238,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn test_flatten() {
+    fn test_keys() {
         let mut root = Node::new("");
 
         root.push("a", "Hello, World!");
@@ -248,13 +230,8 @@ mod tests {
 
         let mut expected = BTreeSet::<String>::new();
         expected.insert("a".to_owned());
-        expected.insert("a_b".to_owned());
-        expected.insert("a_b_c".to_owned());
-        expected.insert("a_b_c_d".to_owned());
-        expected.insert("a_b_c_e".to_owned());
-        expected.insert("a_b_f".to_owned());
 
-        assert_eq!(root.flatten(""), expected);
+        assert_eq!(root.keys(), expected);
     }
     #[test]
     fn test_prefix() {


### PR DESCRIPTION
I encountered an error when I tried to deserialize config
``` rust
#[derive(Debug, Default, Deserialize)]
struct Config {
    pub pools: HashMap<String, PoolConfig>,
}

#[derive(Debug, Default, Deserialize)]
struct PoolConfig {
    pub endpoints: Vec<String>,
    pub size: usize,
}
```
using these environment variables
```
POOLS_FOO_ENDPOINTS="http://localhost:2379"
POOLS_FOO_SIZE = "3"
POOLS_BAR_ENDPOINTS="http://localhost:2379"
POOLS_BAR_SIZE = "3"
```

It causes an error 
```Failed to load config: Error(missing field `endpoints`)```

I found that the `flatten` method is causing all the troubles and it is unsound even for loading all the environment variables into `HashMap<String, String>` because it creates a key for every underscore. So I decided to remove it and replace it with just plain `keys` method.
That change fixed my issue and also an issue in #49 (I uncommented `double_inner_mapping_with_enum_keys` and it worked flawlessly)